### PR TITLE
Speed up logging

### DIFF
--- a/lib/ln.js
+++ b/lib/ln.js
@@ -19,6 +19,15 @@ for (var l in LEVEL) {
   LEVEL[LEVEL[l].toString()] = l;
 }
 
+var curTimeCache;
+var curTime = function() {
+    if (!curTimeCache) {
+		curTimeCache = new Date().getTime();
+		setTimeout(function() { curTimeCache = undefined; }, 1000);
+	}
+	return curTimeCache;
+};
+
 function ln(name, appenders) {
   if (typeof name !== "string" || !name) {
     throw new TypeError("name must be a non-empty string");
@@ -162,7 +171,7 @@ function log(level) {
       return;
     }
 
-    var timestamp = Date.now();
+    var timestamp = curTime();
     this.fields.t = timestamp; //timestamp
     this.fields.l = level;     //level
 


### PR DESCRIPTION
When you are logging many requests, each call must perform as quickly as
possible, adding caching to the timestamp generation speeds it up a
little bit :)
